### PR TITLE
No exception for tracing when running locally

### DIFF
--- a/booking/src/main/java/io/axoniq/demo/hotel/booking/command/config/TracingConfig.java
+++ b/booking/src/main/java/io/axoniq/demo/hotel/booking/command/config/TracingConfig.java
@@ -1,0 +1,26 @@
+package io.axoniq.demo.hotel.booking.command.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.jaegertracing.internal.JaegerTracer;
+import io.jaegertracing.internal.reporters.InMemoryReporter;
+import io.jaegertracing.internal.samplers.ConstSampler;
+import io.jaegertracing.spi.Reporter;
+import io.jaegertracing.spi.Sampler;
+
+@ConditionalOnProperty(value = "opentracing.jaeger.enabled", havingValue = "false", matchIfMissing = false)
+@Configuration
+public class TracingConfig {
+
+    @Bean
+    public io.opentracing.Tracer jaegerTracer() {
+        final Reporter reporter = new InMemoryReporter();
+        final Sampler sampler = new ConstSampler(false);
+        return new JaegerTracer.Builder("untraced-service")
+                .withReporter(reporter)
+                .withSampler(sampler)
+                .build();
+    }
+}

--- a/inventory/src/main/java/io/axoniq/demo/hotel/inventory/config/TracingConfig.java
+++ b/inventory/src/main/java/io/axoniq/demo/hotel/inventory/config/TracingConfig.java
@@ -1,0 +1,26 @@
+package io.axoniq.demo.hotel.inventory.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.jaegertracing.internal.JaegerTracer;
+import io.jaegertracing.internal.reporters.InMemoryReporter;
+import io.jaegertracing.internal.samplers.ConstSampler;
+import io.jaegertracing.spi.Reporter;
+import io.jaegertracing.spi.Sampler;
+
+@ConditionalOnProperty(value = "opentracing.jaeger.enabled", havingValue = "false", matchIfMissing = false)
+@Configuration
+public class TracingConfig {
+
+    @Bean
+    public io.opentracing.Tracer jaegerTracer() {
+        final Reporter reporter = new InMemoryReporter();
+        final Sampler sampler = new ConstSampler(false);
+        return new JaegerTracer.Builder("untraced-service")
+                .withReporter(reporter)
+                .withSampler(sampler)
+                .build();
+    }
+}


### PR DESCRIPTION
When running the hotel demo apps locally an Illegal Argument exception is thrown. This can be prevented by adding this configuration.