### PR TITLE
Add Microk8s section to README and fix front-end URL to work with relative path

### DIFF
--- a/.k8s/README.md
+++ b/.k8s/README.md
@@ -20,6 +20,18 @@ mvn clean verify jib:dockerBuild
 
 [Kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#overview-of-kustomize) is a tool for customizing Kubernetes configurations. It is part of the `kubectl`.
 
+
+### MicroK8s
+When running MicroK8s under Ubuntu Snap, the docker images built by jib are not directly available to Kubernetes. You can import the images to the MicroK8s distribution, using the following commands:
+
+```bash
+cd /tmp
+docker save axoniq-hotel-booking > axoniq-hotel-booking.tar
+docker save axoniq-hotel-inventory > axoniq-hotel-inventory.tar
+microk8s ctr image import axoniq-hotel-booking.tar
+microk8s ctr image import axoniq-hotel-inventory.tar
+```
+
 ## Apply `Standard` configuration
 
 You can run the following command to start your application(s) with `standard` (Axon Server SE) edition:

--- a/inventory/frontend/src/services/room/room.ts
+++ b/inventory/frontend/src/services/room/room.ts
@@ -20,7 +20,7 @@ type CreateRoomBody = {
   description: string;
 };
 export async function createRoom(body: CreateRoomBody) {
-  return await fetchWrapper.post("http://localhost:8081/rooms", body);
+  return await fetchWrapper.post("/rooms", body);
 }
 
 type AddRoomToInventoryProps = {
@@ -28,6 +28,6 @@ type AddRoomToInventoryProps = {
 };
 export async function addRoomToInventory(props: AddRoomToInventoryProps) {
   return await fetchWrapper.post(
-    `http://localhost:8081/rooms/${props.roomNumber}/ininventory`
+    `/rooms/${props.roomNumber}/ininventory`
   );
 }


### PR DESCRIPTION
During my setup I ran into some small issues with the front-end code using a hardcoded localhost URL. When running in MicroK8s (with assigned local IP addresses instead of localhost) the front-end did not work. 